### PR TITLE
Addl worker updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,5 +38,9 @@ pip:
 Features
 --------
 
-* TODO
+* easily spin up a preconfigured cluster with ``get_cluster()``, or flavors with ``get_micro_cluster()``, ``get_standard_cluster()``, ``get_big_cluster()``, or ``get_giant_cluster()``.
 
+.. code-block::python
+
+    >>> import rhg_compute_tools as rhg
+    >>> cluster, client = rhg.get_cluster()

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -150,11 +150,6 @@ def get_cluster(
     if nthreads is not None:
         args[nthreads_ix] = str(nthreads)
 
-    # set memory-limit if provided
-    mem_ix = args.index('--memory-limit') + 1
-    if memory_gb is not None:
-        args[mem_ix] = '{:04.2f}GB'.format(float(memory_gb) * scaling_factor)
-
     # then in resources
     resources = container['resources']
     limits = resources['limits']
@@ -174,11 +169,16 @@ def get_cluster(
 
     format_request = lambda x: '{:04.2f}'.format(np.floor(x*100)/100)
 
+    # set memory-limit if provided
+    mem_ix = args.index('--memory-limit') + 1
+    args[mem_ix] = (
+        format_request(float(memory_gb) * scaling_factor) + 'GB')
+
     limits['memory'] = (
-        format_request(float(memory_gb) * scaling_factor) + 'G')
+        format_request(float(memory_gb) * scaling_factor) + 'GB')
 
     requests['memory'] = (
-        format_request(float(memory_gb) * scaling_factor) + 'G')
+        format_request(float(memory_gb) * scaling_factor) + 'GB')
 
     limits['cpu'] = format_request(float(cpus) * scaling_factor)
     requests['cpu'] = format_request(float(cpus) * scaling_factor)

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -146,7 +146,7 @@ def get_cluster(
     # set memory-limit if provided
     mem_ix = args.index('--memory-limit') + 1
     if memory_gb is not None:
-        args[mem_ix] = '{}GB'.format(memory_gb)
+        args[mem_ix] = '{}GB'.format(memory_gb * scaling_factor)
 
     # then in resources
     resources = container['resources']
@@ -154,12 +154,12 @@ def get_cluster(
     requests = resources['requests']
 
     if memory_gb is not None:
-        limits['memory'] = '{}G'.format(memory_gb)
-        requests['memory'] = '{}G'.format(memory_gb)
+        limits['memory'] = '{}G'.format(memory_gb * scaling_factor)
+        requests['memory'] = '{}G'.format(memory_gb * scaling_factor)
 
     if cpus is not None:
-        limits['cpu'] = str(cpus)
-        requests['cpu'] = str(cpus)
+        limits['cpu'] = str(cpus * scaling_factor)
+        requests['cpu'] = str(cpus * scaling_factor)
 
     # start cluster and client and return
     cluster = dk.KubeCluster.from_dict(template)

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -37,25 +37,25 @@ def get_worker(
 
     Parameters
     ----------
-    name (optional) : str
+    name : str, optional
         Name of worker image to use. If None, default to worker specified in
         `/home/jovyan/worker-template.yml`.
-    extra_pip_packages (optional) : str
+    extra_pip_packages : str, optional
         Extra pip packages to install on worker. Syntax to install is
         "pip install `extra_pip_packages`"
-    extra_conda_packages (optional) :str
+    extra_conda_packages :str, optional
         Same as above except for conda
-    memory_gb (optional) : float
+    memory_gb : float, optional
         Memory to assign per 'group of workers', where a group consists of
         nthreads independent workers.
-    nthreads (optional) : int
+    nthreads : int, optional
         Number of independent threads per group of workers. Not sure if this
         should ever be set to something other than 1.
-    cpus (optional) : float
+    cpus : float, optional
         Number of virtual CPUs to assign per 'group of workers'
-    cred_path (optional) : str or None
+    cred_path : str or None, optional
         Path to Google Cloud credentials file to use.
-    env_items (optional) : list of dict
+    env_items : list of dict, optional
         A list of env variable 'name'-'value' pairs to append to the env variables
         included in worker-template.yml. (e.g. [{'name': 'GCLOUD_DEFAULT_TOKEN_FILE',
         'value': '/opt/gcsfuse_tokens/rhg-data.json'}])

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -105,7 +105,7 @@ def get_cluster(
     See Also
     --------
     :py:func:`get_micro_cluster`, :py:func:`get_standard_cluster`,
-    :py:func:`get_big_cluster`, :py_func:`get_giant_cluster`
+    :py:func:`get_big_cluster`, :py:func:`get_giant_cluster`
     """
 
     with open('/home/jovyan/worker-template.yml', 'r') as f:

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -19,11 +19,27 @@ def traceback(ftr):
     str : Traceback
     """
     return tb.print_exception(
-    type(ftr.exception()),
-    ftr.exception(),
-    ftr.traceback())
+        type(ftr.exception()),
+        ftr.exception(),
+        ftr.traceback())
 
-def get_worker(
+
+def append_docstring(func_with_docstring):
+    def decorator(func):
+        if func.__doc__ is None:
+            func.__doc__ = ''
+        if func_with_docstring.__doc__ is None:
+            func.__doc__ = ''
+
+        func.__doc__ = (
+            func.__doc__
+            + '\n'.join(func_with_docstring.__doc__.lstrip().split('\n')[1:]))
+
+        return func
+    return decorator
+
+
+def get_cluster(
         name=None,
         extra_pip_packages=None,
         extra_conda_packages=None,
@@ -31,18 +47,22 @@ def get_worker(
         nthreads=None,
         cpus=None,
         cred_path=None,
-        env_items=None):
+        env_items=None,
+        scaling_factor=1):
     """
     Start dask.kubernetes cluster and dask.distributed client
+
+    All arguments are optional. If not provided, arguments will default to
+    values provided in ``~/worker-template.yml``.
 
     Parameters
     ----------
     name : str, optional
         Name of worker image to use. If None, default to worker specified in
-        `/home/jovyan/worker-template.yml`.
+        ``/home/jovyan/worker-template.yml``.
     extra_pip_packages : str, optional
         Extra pip packages to install on worker. Syntax to install is
-        "pip install `extra_pip_packages`"
+        ``pip install extra_pip_packages``
     extra_conda_packages :str, optional
         Same as above except for conda
     memory_gb : float, optional
@@ -53,17 +73,39 @@ def get_worker(
         should ever be set to something other than 1.
     cpus : float, optional
         Number of virtual CPUs to assign per 'group of workers'
-    cred_path : str or None, optional
+    cred_path : str, optional
         Path to Google Cloud credentials file to use.
     env_items : list of dict, optional
-        A list of env variable 'name'-'value' pairs to append to the env variables
-        included in worker-template.yml. (e.g. [{'name': 'GCLOUD_DEFAULT_TOKEN_FILE',
-        'value': '/opt/gcsfuse_tokens/rhg-data.json'}])
+        A list of env variable 'name'-'value' pairs to append to the env
+        variables included in ``~/worker-template.yml``, e.g.
+
+        .. code-block:: python
+
+            [{
+                'name': 'GCLOUD_DEFAULT_TOKEN_FILE',
+                'value': '/opt/gcsfuse_tokens/rhg-data.json'}])
+
+    scaling_factor: float, optional
+        scale the worker memory & CPU size using a constant multiplier of the
+        specified worker. No constraints in terms of performance or cluster
+        size are enforced - if you request too little the dask worker will not
+        perform; if you request too much you may see an ``InsufficientMemory``
+        or ``InsufficientCPU`` error on the google cloud Kubernetes console.
+
+        Recommended scaling factors given our default ``~/worker-template.yml``
+        specs are [0.5, 1, 2, 4].
 
     Returns
     -------
-    client : :py:class:dask.distributed.Client
-    cluster : :py:class:dask_kubernetes.KubeCluster
+    client : object
+        :py:class:`dask.distributed.Client` connected to cluster
+    cluster : object
+        Pre-configured :py:class:`dask_kubernetes.KubeCluster`
+
+    See Also
+    --------
+    :py:func:`get_micro_cluster`, :py:func:`get_standard_cluster`,
+    :py:func:`get_big_cluster`, :py_func:`get_giant_cluster`
     """
 
     with open('/home/jovyan/worker-template.yml', 'r') as f:
@@ -76,14 +118,20 @@ def get_worker(
         container['image'] = name
 
     if extra_pip_packages is not None:
-        container['env'].append({'name':'EXTRA_PIP_PACKAGES',
-                                        'value':extra_pip_packages})
+        container['env'].append({
+            'name': 'EXTRA_PIP_PACKAGES',
+            'value': extra_pip_packages})
+
     if extra_conda_packages is not None:
-        container['env'].append({'name':'EXTRA_CONDA_PACKAGES',
-                                        'value':extra_conda_packages})
+        container['env'].append({
+            'name': 'EXTRA_CONDA_PACKAGES',
+            'value': extra_conda_packages})
+
     if cred_path is not None:
-        container['env'].append({'name': 'GCLOUD_DEFAULT_TOKEN_FILE',
-                                 'value': cred_path})
+        container['env'].append({
+            'name': 'GCLOUD_DEFAULT_TOKEN_FILE',
+            'value': cred_path})
+
     if env_items is not None:
         container['env'] = container['env'] + env_items
 
@@ -119,3 +167,39 @@ def get_worker(
     client = dd.Client(cluster)
 
     return client, cluster
+
+
+@append_docstring(get_cluster)
+def get_giant_cluster(*args, **kwargs):
+    """
+    Start a worker with 4x the memory and CPU of the specified worker
+    """
+
+    return get_cluster(*args, scaling_factor=4, **kwargs)
+
+
+@append_docstring(get_cluster)
+def get_big_cluster(*args, **kwargs):
+    """
+    Start a worker with 2x the memory and CPU of the specified worker
+    """
+
+    return get_cluster(*args, scaling_factor=2, **kwargs)
+
+
+@append_docstring(get_cluster)
+def get_standard_cluster(*args, **kwargs):
+    """
+    Start a worker with 1x the memory and CPU of the specified worker
+    """
+
+    return get_cluster(*args, scaling_factor=1, **kwargs)
+
+
+@append_docstring(get_cluster)
+def get_micro_cluster(*args, **kwargs):
+    """
+    Start a worker with 0.5x the memory and CPU of the specified worker
+    """
+
+    return get_cluster(*args, scaling_factor=0.5, **kwargs)

--- a/tests/resources/worker_template.yml
+++ b/tests/resources/worker_template.yml
@@ -1,0 +1,17 @@
+metadata: null
+spec:
+  containers:
+  - args: [dask-worker, --nthreads, '1', --no-bokeh, --memory-limit, 11.5GB, --death-timeout,
+      '60']
+    env:
+    - {name: GCSFUSE_TOKENS, value: '{"bucket": "TOKEN"}'}
+    image: rhodium/worker:v0.2.3
+    name: dask-worker
+    resources:
+      limits: {cpu: '1.75', memory: 11.5G}
+      requests: {cpu: '1.75', memory: 11.5G}
+    securityContext:
+      capabilities:
+        add: [SYS_ADMIN]
+      privileged: true
+  restartPolicy: Never

--- a/tests/test_rhg_compute_tools.py
+++ b/tests/test_rhg_compute_tools.py
@@ -7,17 +7,106 @@ import pytest
 
 from rhg_compute_tools import gcs, kubernetes
 
-@pytest.fixture
-def response():
-    """Sample pytest fixture.
 
-    See more at: http://doc.pytest.org/en/latest/fixture.html
-    """
-    # import requests
-    # return requests.get('https://github.com/audreyr/cookiecutter-pypackage')
+def monkeypatch_cluster(func):
+    def inner(monkeypatch, mem, cpu, scale):
+        def mock_KubeCluster_from_dict(dict_argument):
+            return dict_argument
+
+        def mock_dask_Client(cluster):
+            return cluster
+
+        monkeypatch.setattr(
+            'dask_kubernetes.KubeCluster.from_dict',
+            mock_KubeCluster_from_dict)
+
+        monkeypatch.setattr(
+            'dask.distributed.Client',
+            mock_dask_Client)
+
+        return func(mem=mem, cpu=cpu, scale=scale)
+
+    return inner
 
 
-def test_content(response):
-    """Sample pytest test function with the pytest fixture as an argument."""
-    # from bs4 import BeautifulSoup
-    # assert 'GitHub' in BeautifulSoup(response.content).title.string
+@monkeypatch_cluster
+def test_create_worker():
+
+    cluster, client = kubernetes.get_cluster(
+        template_path='tests/resources/worker_template.yml')
+
+    mem = cluster['spec']['containers'][0]['args'][5]
+    assert mem == '11.5GB', mem
+
+
+@pytest.mark.parametrize("mem,cpu,scale", [(None, None, None)])
+@monkeypatch_cluster
+def test_create_worker(mem=None, cpu=None, scale=None):
+
+    cluster, client = kubernetes.get_cluster(
+        template_path='tests/resources/worker_template.yml')
+
+    mem = cluster['spec']['containers'][0]['args'][5]
+    assert mem == '11.50GB', mem
+
+    res_lim = cluster['spec']['containers'][0]['resources']['limits']
+    assert res_lim['memory'] == '11.50GB', res_lim['memory']
+    assert res_lim['cpu'] == '1.75', res_lim['cpu']
+
+    res_req = cluster['spec']['containers'][0]['resources']['requests']
+    assert res_req['memory'] == '11.50GB', res_req['memory']
+    assert res_req['cpu'] == '1.75', res_req['cpu']
+
+
+size_test_params = [(35, 7, None), (1, 6, None), (4, 1, None)]
+
+
+@pytest.mark.parametrize("mem,cpu,scale", size_test_params)
+@monkeypatch_cluster
+def test_size_worker(mem, cpu, scale):
+
+    cluster, client = kubernetes.get_cluster(
+        template_path='tests/resources/worker_template.yml',
+        memory_gb=mem,
+        cpus=cpu)
+
+    mem_arg = cluster['spec']['containers'][0]['args'][5]
+    assert abs(mem - float(mem_arg.strip('GB'))) < 0.01, mem_arg
+
+    res_lim = cluster['spec']['containers'][0]['resources']['limits']
+    assert abs(float(res_lim['memory'].strip('GB')) - mem) < 0.01, res_lim['memory']
+    assert abs(float(res_lim['cpu']) - cpu) < 0.01, res_lim['cpu']
+
+    res_req = cluster['spec']['containers'][0]['resources']['requests']
+    assert abs(float(res_req['memory'].strip('GB')) - mem) < 0.01, res_req['memory']
+    assert abs(float(res_req['cpu']) - cpu) < 0.01, res_req['cpu']
+
+
+
+scale_test_params = [
+    (None, None, 0.5),
+    (None, None, 1),
+    (None, None, 2),
+    (None, None, 4)]
+
+
+@pytest.mark.parametrize("mem,cpu,scale", scale_test_params)
+@monkeypatch_cluster
+def test_scale_worker(mem, cpu,scale):
+
+    cluster, client = kubernetes.get_cluster(
+        template_path='tests/resources/worker_template.yml',
+        scaling_factor=scale)
+
+    mem_arg = cluster['spec']['containers'][0]['args'][5]
+    assert abs((scale * 11.5) - float(mem_arg.strip('GB'))) < 0.01, mem_arg
+
+    res_lim = cluster['spec']['containers'][0]['resources']['limits']
+    mem_val = float(res_lim['memory'].strip('GB'))
+    assert abs(mem_val - (scale * 11.5)) < 0.01, res_lim['memory']
+    assert abs(float(res_lim['cpu']) - (scale * 1.75)) < 0.01, res_lim['cpu']
+
+    res_req = cluster['spec']['containers'][0]['resources']['requests']
+    mem_val = float(res_req['memory'].strip('GB'))
+    assert abs(mem_val - (scale * 11.5)) < 0.01, res_req['memory']
+    assert abs(float(res_req['cpu']) - (scale * 1.75)) < 0.01, res_req['cpu']

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, flake8
+envlist = py27, py35, py36, flake8, docs
 
 [travis]
 python =
@@ -11,6 +11,19 @@ python =
 basepython=python
 deps=flake8
 commands=flake8 rhg_compute_tools
+
+[testenv:docs]
+basepython=python
+setenv = 
+    PYTHONPATH = {toxinidir}
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements_dev.txt
+    -r{toxinidir}/requirements_conda.txt
+commands =
+    rm -f docs/rhg_compute_tools*.rst
+    sphinx-apidoc -o docs rhg_compute_tools
+    sphinx-build -W -b html -d docs/_build/doctrees docs/. docs/_build/html
 
 [testenv]
 setenv =


### PR DESCRIPTION
 - [x] closes #3
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 rhg_compute_tools tests docs``
 - [ ] entry in HISTORY.rst

This PR includes the following modifications:
* `get_worker` is renamed `get_cluster`
* Default parameters to `get_cluster` are pulled from `worker_template.yml` rather than overwritten. this is super important to allow for different cluster specifications on [compute.rhg](https://compute.rhg.com), [compute-test.rhg](https://compute-test.rhg.com), and [compute.impactlab](https://compute.impactlab.org).
* Helper functions to create different cluster flavors are created (`get_micro_cluster`, `get_standard_cluster`, `get_big_cluster`, `get_giant_cluster`).