### PR TITLE
bug fix in kubernetes.get_cluster

### DIFF
--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -178,10 +178,10 @@ def get_cluster(
         format_request(float(memory_gb) * scaling_factor) + 'GB')
 
     limits['memory'] = (
-        format_request(float(memory_gb) * scaling_factor) + 'GB')
+        format_request(float(memory_gb) * scaling_factor) + 'G')
 
     requests['memory'] = (
-        format_request(float(memory_gb) * scaling_factor) + 'GB')
+        format_request(float(memory_gb) * scaling_factor) + 'G')
 
     limits['cpu'] = format_request(float(cpus) * scaling_factor)
     requests['cpu'] = format_request(float(cpus) * scaling_factor)

--- a/tests/test_rhg_compute_tools.py
+++ b/tests/test_rhg_compute_tools.py
@@ -41,11 +41,11 @@ def test_create_worker(mem=None, cpu=None, scale=None):
     assert mem == '11.50GB', mem
 
     res_lim = cluster['spec']['containers'][0]['resources']['limits']
-    assert res_lim['memory'] == '11.50GB', res_lim['memory']
+    assert res_lim['memory'] == '11.50G', res_lim['memory']
     assert res_lim['cpu'] == '1.75', res_lim['cpu']
 
     res_req = cluster['spec']['containers'][0]['resources']['requests']
-    assert res_req['memory'] == '11.50GB', res_req['memory']
+    assert res_req['memory'] == '11.50G', res_req['memory']
     assert res_req['cpu'] == '1.75', res_req['cpu']
 
 
@@ -65,12 +65,12 @@ def test_size_worker(mem, cpu, scale):
     assert abs(mem - float(mem_arg.strip('GB'))) < 0.01, mem_arg
 
     res_lim = cluster['spec']['containers'][0]['resources']['limits']
-    mem_size = float(res_lim['memory'].strip('GB'))
+    mem_size = float(res_lim['memory'].strip('G'))
     assert abs(mem_size - mem) < 0.01, res_lim['memory']
     assert abs(float(res_lim['cpu']) - cpu) < 0.01, res_lim['cpu']
 
     res_req = cluster['spec']['containers'][0]['resources']['requests']
-    mem_size = float(res_req['memory'].strip('GB'))
+    mem_size = float(res_req['memory'].strip('G'))
     assert abs(mem_size - mem) < 0.01, res_req['memory']
     assert abs(float(res_req['cpu']) - cpu) < 0.01, res_req['cpu']
 
@@ -94,12 +94,12 @@ def test_scale_worker(mem, cpu, scale):
     assert abs((scale * 11.5) - float(mem_arg.strip('GB'))) < 0.01, mem_arg
 
     res_lim = cluster['spec']['containers'][0]['resources']['limits']
-    mem_val = float(res_lim['memory'].strip('GB'))
+    mem_val = float(res_lim['memory'].strip('G'))
     assert abs(mem_val - (scale * 11.5)) < 0.01, res_lim['memory']
     assert abs(float(res_lim['cpu']) - (scale * 1.75)) < 0.01, res_lim['cpu']
 
     res_req = cluster['spec']['containers'][0]['resources']['requests']
-    mem_val = float(res_req['memory'].strip('GB'))
+    mem_val = float(res_req['memory'].strip('G'))
     assert abs(mem_val - (scale * 11.5)) < 0.01, res_req['memory']
     assert abs(float(res_req['cpu']) - (scale * 1.75)) < 0.01, res_req['cpu']
 


### PR DESCRIPTION
 - [x] closes #21 
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 rhg_compute_tools tests docs``
 - [ ] entry in HISTORY.rst

Bug fix in kubernetes.get_cluster:

resources/requests memory amount should be specified in `'G'` not `'GB'`