### PR TITLE
update sync_gcs cp_gcs to go bidirectional

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,6 +5,6 @@ flake8==3.5.0
 tox==3.0.0
 coverage==4.5.1
 Sphinx==1.7.4
-PyYAML==3.12
+pyyaml>=4.2b1
 pytest-cov==2.5.1
 pytest-runner==4.2


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [x] docs reflect changes
 - [ ] passes ``flake8 rhg_compute_tools tests docs``
 - [ ] entry in HISTORY.rst

Updates `cp_to_gcs` and `sync_to_gcs` to `cp_gcs` and `sync_gcs` in order to enable copying/syncing to and from gcs.