### PR TITLE
Add function replicate_directory_structure_on_gcs

### DIFF
--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -79,9 +79,14 @@ def replicate_directory_structure_on_gcs(src, dst, storage_client):
 
     for d, dirnames, files in os.walk(src):
         dest_path = os.path.join(blob_path, os.path.relpath(d, src))
-        
+
         # make sure there is exactly one trailing slash:
         dest_path = dest_path.rstrip('/') + '/'
+
+        # ignore "." directory
+        if dest_path == './':
+            continue
+
         blob = bucket.blob(dest_path)
         blob.upload_from_string('')
 

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -82,7 +82,7 @@ def replicate_directory_structure_on_gcs(src, dst, storage_client):
         
         # make sure there is exactly one trailing slash:
         dest_path = dest_path.rstrip('/') + '/'
-        blob = bucket.Blob(dest_path)
+        blob = bucket.blob(dest_path)
         blob.upload_from_string('')
 
 

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -77,7 +77,7 @@ def replicate_directory_structure_on_gcs(src, dst, storage_client):
     
     bucket = storage_client.get_bucket(bucket_name)
 
-    for d in os.walk(src):
+    for d, dirnames, files in os.walk(src):
         dest_path = os.path.join(blob_path, os.path.relpath(d, src))
         
         # make sure there is exactly one trailing slash:


### PR DESCRIPTION
Adds a function `replicate_directory_structure_on_gcs` which replicates a local directory structure on google cloud storage

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 rhg_compute_tools tests docs``
 - [ ] entry in HISTORY.rst

@brews give this a spin