### PR TITLE
WIP: Add CLI for `replicate_directory_structure_on_gcs()`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,12 @@ History
 
 .. current developments
 
+v0.2.0
+------
+
+* Add CLI tools. See ``rctools gcs repdirstruc --help`` to start.
+
+
 v0.1.8
 ------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,24 @@ History
 
 .. current developments
 
+v0.1.8
+------
+
+* Deployment fixes.
+
+v0.1.7
+------
+
+* Design tools: use RHG & CIL colors & styles
+* Plotting helpers: generate cmaps with consistent colors & norms, and apply a colorbar to geopandas plots with nonlinear norms
+* Autoscaling fix for kubecluster: switch to dask_kubernetes.KubeCluster to allow use of recent bug fixes
+
+
+v0.1.6
+------
+
+* Add :py:func:`rhg_compute_tools.gcs.cp_gcs` and :py:func:`rhg_compute_tools.gcs.sync_gcs` utilities
+
 v0.1.5
 ------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,15 +7,15 @@ History
 v0.2.0
 ------
 
-* Add CLI tools. See ``rctools gcs repdirstruc --help`` to start.
-* Add new function ``rhg_compute_tools.gcs.replicate_directory_structure_on_gcs`` to copy directory trees into GCS.
-* Fixes to docstrings and metadata (e.g. :issue:`43`, :issue:`45`).
+* Add CLI tools (:issue:`37`). See ``rctools gcs repdirstruc --help`` to start
+* Add new function ``rhg_compute_tools.gcs.replicate_directory_structure_on_gcs`` to copy directory trees into GCS
+* Fixes to docstrings and metadata (:issue:`43`) (:issue:`45`)
 
 
 v0.1.8
 ------
 
-* Deployment fixes.
+* Deployment fixes
 
 v0.1.7
 ------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ v0.2.0
 ------
 
 * Add CLI tools. See ``rctools gcs repdirstruc --help`` to start.
+* Add new function :py:func:`rhg_compute_tools.gcs.replicate_directory_structure_on_gcs` to copy directory trees into GCS.
+* Fixes to docstrings and metadata (e.g. :issue:`43`, :issue:`45`).
 
 
 v0.1.8

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ v0.2.0
 ------
 
 * Add CLI tools. See ``rctools gcs repdirstruc --help`` to start.
-* Add new function :py:func:`rhg_compute_tools.gcs.replicate_directory_structure_on_gcs` to copy directory trees into GCS.
+* Add new function ``rhg_compute_tools.gcs.replicate_directory_structure_on_gcs`` to copy directory trees into GCS.
 * Fixes to docstrings and metadata (e.g. :issue:`43`, :issue:`45`).
 
 
@@ -28,7 +28,7 @@ v0.1.7
 v0.1.6
 ------
 
-* Add :py:func:`rhg_compute_tools.gcs.cp_gcs` and :py:func:`rhg_compute_tools.gcs.sync_gcs` utilities
+* Add ``rhg_compute_tools.gcs.cp_gcs`` and ``rhg_compute_tools.gcs.sync_gcs`` utilities
 
 v0.1.5
 ------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ google-cloud-storage==1.16.1
 dask-kubernetes==0.8.0
 matplotlib==3.0.3
 numpy>=1.14
+click

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,4 +8,5 @@ Sphinx==1.7.4
 pyyaml>=4.2b1
 pytest-cov==2.5.1
 pytest-runner==4.2
+pytest-mock
 twine==1.13.0

--- a/rhg_compute_tools/cli.py
+++ b/rhg_compute_tools/cli.py
@@ -5,12 +5,12 @@ from rhg_compute_tools.gcs import replicate_directory_structure_on_gcs
 @click.group(
     context_settings={'help_option_names': ['-h', '--help']}
 )
-def rct_cli():
+def rctools_cli():
     """Rhodium Compute Tools"""
     pass
 
 
-@rct_cli.group()
+@rctools_cli.group()
 def gcs():
     """Tools for interacting with Google Cloud Storage
     """
@@ -21,8 +21,8 @@ def gcs():
 @click.argument('src', type=click.Path(exists=True))
 @click.argument('dst', type=click.Path())
 @click.option('-c', '--credentials', type=click.Path(exists=True),
-                envvar='GOOGLE_APPLICATION_CREDENTIALS',
-                help='Optional path to GCS credentials file.')
+              envvar='GOOGLE_APPLICATION_CREDENTIALS',
+              help='Optional path to GCS credentials file.')
 def repdirstruc(src, dst, credentials):
     """Replicate a local directory structure onto GCS bucket.
     """

--- a/rhg_compute_tools/cli.py
+++ b/rhg_compute_tools/cli.py
@@ -1,0 +1,29 @@
+import click
+from rhg_compute_tools.gcs import replicate_directory_structure_on_gcs
+
+
+@click.group(
+    context_settings={'help_option_names': ['-h', '--help']}
+)
+def rct_cli():
+    """Rhodium Compute Tools"""
+    pass
+
+
+@rct_cli.group()
+def gcs():
+    """Tools for interacting with Google Cloud Storage
+    """
+    pass
+
+
+@gcs.command()
+@click.argument('src', type=click.Path(exists=True))
+@click.argument('dst', type=click.Path())
+@click.option('-c', '--credentials', type=click.Path(exists=True),
+                envvar='GOOGLE_APPLICATION_CREDENTIALS',
+                help='Optional path to GCS credentials file.')
+def repdirstruc(src, dst, credentials):
+    """Replicate a local directory structure onto GCS bucket.
+    """
+    replicate_directory_structure_on_gcs(src, dst, credentials)

--- a/rhg_compute_tools/cli.py
+++ b/rhg_compute_tools/cli.py
@@ -24,6 +24,13 @@ def gcs():
               envvar='GOOGLE_APPLICATION_CREDENTIALS',
               help='Optional path to GCS credentials file.')
 def repdirstruc(src, dst, credentials):
-    """Replicate a local directory structure onto GCS bucket.
+    """Replicate directory structure onto GCS bucket.
+
+    SRC is path to a local directory. Directories within will be replicated.
+    DST is gs://[bucket] and optional path to replicate SRC into.
+
+    If --credentials or -c is not explicitly given, checks the
+    GOOGLE_APPLICATIONS_CREDENTIALS environment variable for path to a GCS
+    credentials file.
     """
     replicate_directory_structure_on_gcs(src, dst, credentials)

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -47,13 +47,12 @@ def _get_path_types(src, dest):
     return src_gs, dest_gs, dest_gcs
 
 
-def replicate_directory_structure_on_gcs(src, dst, storage_client):
-    '''
+def replicate_directory_structure_on_gcs(src, dst, client_or_creds):
+    """
     Replicate a local directory structure on google cloud storage
-    
+
     Parameters
     ----------
-    
     src : str
         Path to the root directory on the source machine. The directory
         structure within this directory will be reproduced within `dst`,
@@ -61,9 +60,15 @@ def replicate_directory_structure_on_gcs(src, dst, storage_client):
     dst : str
         A url for the root directory of the destination, starting with
         `gs://[bucket_name]/`, e.g. `gs://my_bucket/path/to/my/data`
-    storage_client : object
-        An authenticated :py:class:`google.cloud.storage.client.Client` object
-    '''
+    client_or_creds : google.cloud.storage.client.Client or str
+        An authenticated :py:class:`google.cloud.storage.client.Client` object,
+        or a str path to storage credentials authentication file.
+    """
+    if isinstance(client_or_creds, str):
+        credentials = service_account.Credentials.from_service_account_file(
+            client_or_creds
+        )
+        client_or_creds = storage.Client(credentials=credentials)
 
     if dst.startswith('gs://'):
         dst = dst[5:]
@@ -71,11 +76,11 @@ def replicate_directory_structure_on_gcs(src, dst, storage_client):
         dst = dst[6:]
     else:
         raise ValueError('dst must begin with `gs://` or `gcs://`')
-    
+
     bucket_name = dst.split('/')[0]
     blob_path = '/'.join(dst.split('/')[1:])
-    
-    bucket = storage_client.get_bucket(bucket_name)
+
+    bucket = client_or_creds.get_bucket(bucket_name)
 
     for d, dirnames, files in os.walk(src):
         dest_path = os.path.join(blob_path, os.path.relpath(d, src))

--- a/setup.py
+++ b/setup.py
@@ -60,4 +60,9 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     setup_requires=setup_requirements,
+    entry_points={
+        'console_scripts': [
+            'rct = rhg_compute_tools.cli:rct_cli',
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     setup_requires=setup_requirements,
     entry_points={
         'console_scripts': [
-            'rct = rhg_compute_tools.cli:rct_cli',
+            'rctools = rhg_compute_tools.cli:rctools_cli',
         ]
     },
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,77 @@
+"""
+White-box testing to ensure that CLI passes variables correctly
+"""
+
+
+import pytest
+import click
+from click.testing import CliRunner
+import rhg_compute_tools.cli
+
+
+@pytest.fixture
+def replicate_directory_structure_on_gcs_stub(mocker):
+    mocker.patch.object(rhg_compute_tools.cli,
+                        'replicate_directory_structure_on_gcs',
+                        new=lambda *args: click.echo(';'.join(args)))
+
+
+@pytest.fixture
+def tempfl_path(tmpdir):
+    """Creates a temporary file, returning its path"""
+    file = tmpdir.join('file.json')
+    file.write('foobar')
+    return str(file)
+
+
+@pytest.mark.parametrize('credflag', ['-c', '--credentials', None])
+def test_repdirstruc(credflag, replicate_directory_structure_on_gcs_stub,
+                     tmpdir, tempfl_path, monkeypatch):
+    """Test rct gcs repdirstruc for main input options"""
+    # Setup CLI args
+    cred_path = str(tempfl_path)
+    credargs = [credflag, cred_path]
+    src_path = str(tmpdir)
+    dst_path = 'gcs://foo/bar'
+
+    if credflag is None:
+        monkeypatch.setenv('GOOGLE_APPLICATION_CREDENTIALS', cred_path)
+        credargs = []
+
+    # Run CLI
+    runner = CliRunner()
+    result = runner.invoke(
+        rhg_compute_tools.cli.rct_cli,
+        ['gcs', 'repdirstruc'] + credargs + [src_path, dst_path],
+    )
+
+    expected_output = ';'.join([src_path, dst_path, cred_path]) + '\n'
+    assert result.output == expected_output
+
+
+@pytest.mark.parametrize('credflag', ['-c', '--credentials', None])
+def test_repdirstruc_nocredfile(credflag, replicate_directory_structure_on_gcs_stub,
+                                tmpdir, monkeypatch):
+    """Test rct gcs repdirstruc for graceful fail when cred file missing"""
+    # Setup CLI args
+    cred_path = '_foobar.json'
+    credargs = [credflag, cred_path]
+    src_path = str(tmpdir)
+    dst_path = 'gcs://foo/bar'
+
+    if credflag is None:
+        monkeypatch.setenv('GOOGLE_APPLICATION_CREDENTIALS', cred_path)
+        credargs = []
+
+    # Run CLI
+    runner = CliRunner()
+    result = runner.invoke(
+        rhg_compute_tools.cli.rct_cli,
+        ['gcs', 'repdirstruc'] + credargs + [src_path, dst_path],
+    )
+
+    expected_output = 'Usage: rct-cli gcs repdirstruc [OPTIONS] SRC DST\nTry' \
+                      ' "rct-cli gcs repdirstruc -h" for help.\n\nError: ' \
+                      'Invalid value for "-c" / "--credentials": Path ' \
+                      '"_foobar.json" does not exist.\n'
+    assert result.output == expected_output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,8 @@ def tempfl_path(tmpdir):
 @pytest.mark.parametrize('credflag', ['-c', '--credentials', None])
 def test_repdirstruc(credflag, replicate_directory_structure_on_gcs_stub,
                      tmpdir, tempfl_path, monkeypatch):
-    """Test rct gcs repdirstruc for main input options"""
+    """Test rctools gcs repdirstruc for main input options
+    """
     # Setup CLI args
     cred_path = str(tempfl_path)
     credargs = [credflag, cred_path]
@@ -41,7 +42,7 @@ def test_repdirstruc(credflag, replicate_directory_structure_on_gcs_stub,
     # Run CLI
     runner = CliRunner()
     result = runner.invoke(
-        rhg_compute_tools.cli.rct_cli,
+        rhg_compute_tools.cli.rctools_cli,
         ['gcs', 'repdirstruc'] + credargs + [src_path, dst_path],
     )
 
@@ -52,7 +53,8 @@ def test_repdirstruc(credflag, replicate_directory_structure_on_gcs_stub,
 @pytest.mark.parametrize('credflag', ['-c', '--credentials', None])
 def test_repdirstruc_nocredfile(credflag, replicate_directory_structure_on_gcs_stub,
                                 tmpdir, monkeypatch):
-    """Test rct gcs repdirstruc for graceful fail when cred file missing"""
+    """Test rctools gcs repdirstruc for graceful fail when cred file missing
+    """
     # Setup CLI args
     cred_path = '_foobar.json'
     credargs = [credflag, cred_path]
@@ -66,12 +68,12 @@ def test_repdirstruc_nocredfile(credflag, replicate_directory_structure_on_gcs_s
     # Run CLI
     runner = CliRunner()
     result = runner.invoke(
-        rhg_compute_tools.cli.rct_cli,
+        rhg_compute_tools.cli.rctools_cli,
         ['gcs', 'repdirstruc'] + credargs + [src_path, dst_path],
     )
 
-    expected_output = 'Usage: rct-cli gcs repdirstruc [OPTIONS] SRC DST\nTry' \
-                      ' "rct-cli gcs repdirstruc -h" for help.\n\nError: ' \
+    expected_output = 'Usage: rctools-cli gcs repdirstruc [OPTIONS] SRC DST\nTry' \
+                      ' "rctools-cli gcs repdirstruc -h" for help.\n\nError: ' \
                       'Invalid value for "-c" / "--credentials": Path ' \
                       '"_foobar.json" does not exist.\n'
     assert result.output == expected_output


### PR DESCRIPTION
 - [x] closes #37 #43 #45 
 - [x] tests added / passed
 - [ ] docs reflect changes
 - [x] passes ``flake8 rhg_compute_tools tests docs``
 - [x] entry in HISTORY.rst

This adds basic structure for CLI tools. I used a CLI version of `replicate_directory_structure_on_gcs()` as a starting point.

Here is how it works. Assuming the user installed via pip or conda or whatever. Open command line and run

```
rctools gcs repdirstruc dir1 gs://my-gcs-bucket/
```

Which copies any nested directory structure in "dir1" into "gs://my-gcs-bucket/". You can see help with

```
rctools gcs repdirstruc --help
```

and this works for all subcommands, so

```
rctools --help
```

will list and briefly describe all of the subcommands available.

Note that I had to extend `replicate_directory_structure_on_gcs()` and change its signature so that it now takes an optional authorized client *or a path to GCS credentials* for the `client_or_creds` arg.

This PR also has a few other minor cleanups to HISTORY and package metadata. It adds `click` and `pytest-mock` as dependencies.
