### PR TITLE
Alternative approach to enable alt GCS auth

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ v0.2.0
 ------
 
 * Add CLI tools (:issue:`37`). See ``rctools gcs repdirstruc --help`` to start
-* Add new function ``rhg_compute_tools.gcs.replicate_directory_structure_on_gcs`` to copy directory trees into GCS
+* Add new function ``rhg_compute_tools.gcs.replicate_directory_structure_on_gcs`` to copy directory trees into GCS. Users can authenticate with cred_file or with default google credentials (:issue:`51`)
 * Fixes to docstrings and metadata (:issue:`43`) (:issue:`45`)
 
 

--- a/rhg_compute_tools/cli.py
+++ b/rhg_compute_tools/cli.py
@@ -1,5 +1,6 @@
 import click
-from rhg_compute_tools.gcs import replicate_directory_structure_on_gcs
+from rhg_compute_tools.gcs import (replicate_directory_structure_on_gcs,
+                                   _authenticate_client)
 
 
 @click.group(
@@ -21,7 +22,6 @@ def gcs():
 @click.argument('src', type=click.Path(exists=True))
 @click.argument('dst', type=click.Path())
 @click.option('-c', '--credentials', type=click.Path(exists=True),
-              envvar='GOOGLE_APPLICATION_CREDENTIALS',
               help='Optional path to GCS credentials file.')
 def repdirstruc(src, dst, credentials):
     """Replicate directory structure onto GCS bucket.
@@ -31,6 +31,9 @@ def repdirstruc(src, dst, credentials):
 
     If --credentials or -c is not explicitly given, checks the
     GOOGLE_APPLICATION_CREDENTIALS environment variable for path to a GCS
-    credentials file.
+    credentials file, or default service accounts for authentication. See
+    https://googleapis.dev/python/google-api-core/latest/auth.html for more
+    details.
     """
-    replicate_directory_structure_on_gcs(src, dst, credentials)
+    client = _authenticate_client(credentials)
+    replicate_directory_structure_on_gcs(src, dst, client)

--- a/rhg_compute_tools/cli.py
+++ b/rhg_compute_tools/cli.py
@@ -1,6 +1,6 @@
 import click
 from rhg_compute_tools.gcs import (replicate_directory_structure_on_gcs,
-                                   _authenticate_client)
+                                   authenticated_client)
 
 
 @click.group(
@@ -35,5 +35,5 @@ def repdirstruc(src, dst, credentials):
     https://googleapis.dev/python/google-api-core/latest/auth.html for more
     details.
     """
-    client = _authenticate_client(credentials)
+    client = authenticated_client(credentials)
     replicate_directory_structure_on_gcs(src, dst, client)

--- a/rhg_compute_tools/cli.py
+++ b/rhg_compute_tools/cli.py
@@ -30,7 +30,7 @@ def repdirstruc(src, dst, credentials):
     DST is gs://[bucket] and optional path to replicate SRC into.
 
     If --credentials or -c is not explicitly given, checks the
-    GOOGLE_APPLICATIONS_CREDENTIALS environment variable for path to a GCS
+    GOOGLE_APPLICATION_CREDENTIALS environment variable for path to a GCS
     credentials file.
     """
     replicate_directory_structure_on_gcs(src, dst, credentials)

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -11,7 +11,7 @@ import subprocess
 import shlex
 
 
-def _authenticate_client(credentials=None):
+def authenticated_client(credentials=None):
     """Convenience function to create an authenticated GCS client.
 
     Parameters

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -69,6 +69,8 @@ def replicate_directory_structure_on_gcs(src, dst, client_or_creds):
             client_or_creds
         )
         client_or_creds = storage.Client(credentials=credentials)
+    elif client_or_creds is None:
+        client_or_creds = storage.Client()
 
     if dst.startswith('gs://'):
         dst = dst[5:]

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -47,7 +47,7 @@ def _get_path_types(src, dest):
     return src_gs, dest_gs, dest_gcs
 
 
-def replicate_directory_structure_on_gcs(src, dst, client_or_creds):
+def replicate_directory_structure_on_gcs(src, dst, client_or_creds=None):
     """
     Replicate a local directory structure on google cloud storage
 
@@ -60,9 +60,14 @@ def replicate_directory_structure_on_gcs(src, dst, client_or_creds):
     dst : str
         A url for the root directory of the destination, starting with
         `gs://[bucket_name]/`, e.g. `gs://my_bucket/path/to/my/data`
-    client_or_creds : google.cloud.storage.client.Client or str
+    client_or_creds : google.cloud.storage.client.Client or str, optional
         An authenticated :py:class:`google.cloud.storage.client.Client` object,
-        or a str path to storage credentials authentication file.
+        or a str path to storage credentials authentication file. If None
+        is passed (default) will create a Client object with no args, using
+        the authorization credentials for the current environment. See the
+        [google cloud storage docs](
+        https://googleapis.dev/python/google-api-core/latest/auth.html)
+        for an overview of the authorization options.
     """
     if isinstance(client_or_creds, str):
         credentials = service_account.Credentials.from_service_account_file(

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -11,6 +11,34 @@ import subprocess
 import shlex
 
 
+def _authenticate_client(credentials=None):
+    """Convenience function to create an authenticated GCS client.
+
+    Parameters
+    ----------
+    credentials : str or None, optional
+        Str path to storage credentials authentication file. If None
+        is passed (default) will create a Client object with no args, using
+        the authorization credentials for the current environment. See the
+        [google cloud storage docs](
+        https://googleapis.dev/python/google-api-core/latest/auth.html)
+        for an overview of the authorization options.
+
+    Returns
+    -------
+    google.cloud.storage.Client
+    """
+    if credentials is None:
+        client = storage.Client()
+    else:
+        creds = service_account.Credentials.from_service_account_file(
+            str(credentials)
+        )
+        client = storage.Client(credentials=creds)
+
+    return client
+
+
 def get_bucket(cred_path):
     '''Return a bucket object from Rhg's GCS system.
 
@@ -47,7 +75,7 @@ def _get_path_types(src, dest):
     return src_gs, dest_gs, dest_gcs
 
 
-def replicate_directory_structure_on_gcs(src, dst, client_or_creds=None):
+def replicate_directory_structure_on_gcs(src, dst, client):
     """
     Replicate a local directory structure on google cloud storage
 
@@ -60,23 +88,9 @@ def replicate_directory_structure_on_gcs(src, dst, client_or_creds=None):
     dst : str
         A url for the root directory of the destination, starting with
         `gs://[bucket_name]/`, e.g. `gs://my_bucket/path/to/my/data`
-    client_or_creds : google.cloud.storage.client.Client or str, optional
-        An authenticated :py:class:`google.cloud.storage.client.Client` object,
-        or a str path to storage credentials authentication file. If None
-        is passed (default) will create a Client object with no args, using
-        the authorization credentials for the current environment. See the
-        [google cloud storage docs](
-        https://googleapis.dev/python/google-api-core/latest/auth.html)
-        for an overview of the authorization options.
+    client : google.cloud.storage.client.Client
+        An authenticated :py:class:`google.cloud.storage.client.Client` object.
     """
-    if isinstance(client_or_creds, str):
-        credentials = service_account.Credentials.from_service_account_file(
-            client_or_creds
-        )
-        client_or_creds = storage.Client(credentials=credentials)
-    elif client_or_creds is None:
-        client_or_creds = storage.Client()
-
     if dst.startswith('gs://'):
         dst = dst[5:]
     elif dst.startswith('gcs://'):
@@ -87,7 +101,7 @@ def replicate_directory_structure_on_gcs(src, dst, client_or_creds=None):
     bucket_name = dst.split('/')[0]
     blob_path = '/'.join(dst.split('/')[1:])
 
-    bucket = client_or_creds.get_bucket(bucket_name)
+    bucket = client.get_bucket(bucket_name)
 
     for d, dirnames, files in os.walk(src):
         dest_path = os.path.join(blob_path, os.path.relpath(d, src))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ def replicate_directory_structure_on_gcs_stub(mocker):
         'replicate_directory_structure_on_gcs',
         new=lambda *args: click.echo(';'.join(args)),
     )
-    mocker.patch.object(rhg_compute_tools.cli, '_authenticate_client',
+    mocker.patch.object(rhg_compute_tools.cli, 'authenticated_client',
                         new=lambda x: str(x))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,9 +11,13 @@ import rhg_compute_tools.cli
 
 @pytest.fixture
 def replicate_directory_structure_on_gcs_stub(mocker):
-    mocker.patch.object(rhg_compute_tools.cli,
-                        'replicate_directory_structure_on_gcs',
-                        new=lambda *args: click.echo(';'.join(args)))
+    mocker.patch.object(
+        rhg_compute_tools.cli,
+        'replicate_directory_structure_on_gcs',
+        new=lambda *args: click.echo(';'.join(args)),
+    )
+    mocker.patch.object(rhg_compute_tools.cli, '_authenticate_client',
+                        new=lambda x: str(x))
 
 
 @pytest.fixture
@@ -36,8 +40,8 @@ def test_repdirstruc(credflag, replicate_directory_structure_on_gcs_stub,
     dst_path = 'gcs://foo/bar'
 
     if credflag is None:
-        monkeypatch.setenv('GOOGLE_APPLICATION_CREDENTIALS', cred_path)
         credargs = []
+        cred_path = str(None)
 
     # Run CLI
     runner = CliRunner()
@@ -50,8 +54,9 @@ def test_repdirstruc(credflag, replicate_directory_structure_on_gcs_stub,
     assert result.output == expected_output
 
 
-@pytest.mark.parametrize('credflag', ['-c', '--credentials', None])
-def test_repdirstruc_nocredfile(credflag, replicate_directory_structure_on_gcs_stub,
+@pytest.mark.parametrize('credflag', ['-c', '--credentials'])
+def test_repdirstruc_nocredfile(credflag,
+                                replicate_directory_structure_on_gcs_stub,
                                 tmpdir, monkeypatch):
     """Test rctools gcs repdirstruc for graceful fail when cred file missing
     """
@@ -61,10 +66,6 @@ def test_repdirstruc_nocredfile(credflag, replicate_directory_structure_on_gcs_s
     src_path = str(tmpdir)
     dst_path = 'gcs://foo/bar'
 
-    if credflag is None:
-        monkeypatch.setenv('GOOGLE_APPLICATION_CREDENTIALS', cred_path)
-        credargs = []
-
     # Run CLI
     runner = CliRunner()
     result = runner.invoke(
@@ -72,8 +73,8 @@ def test_repdirstruc_nocredfile(credflag, replicate_directory_structure_on_gcs_s
         ['gcs', 'repdirstruc'] + credargs + [src_path, dst_path],
     )
 
-    expected_output = 'Usage: rctools-cli gcs repdirstruc [OPTIONS] SRC DST\nTry' \
-                      ' "rctools-cli gcs repdirstruc -h" for help.\n\nError: ' \
-                      'Invalid value for "-c" / "--credentials": Path ' \
-                      '"_foobar.json" does not exist.\n'
-    assert result.output == expected_output
+    expected = 'Usage: rctools-cli gcs repdirstruc [OPTIONS] SRC DST\nTry' \
+               ' "rctools-cli gcs repdirstruc -h" for help.\n\nError: ' \
+               'Invalid value for "-c" / "--credentials": Path ' \
+               '"_foobar.json" does not exist.\n'
+    assert result.output == expected


### PR DESCRIPTION
 - [x] closes #51
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 rhg_compute_tools tests docs``
 - [x] entry in HISTORY.rst

This PR presents an alternative approach to PR #49. 

I refactored how we create authenticated clients. Minor refactor to how we mock the CLI tests. Reverted the earlier change to `rhg_compute_tools.gcs.replicate_directory_structure_on_gcs()` signature -- here it no longer accepting certificates and requires an authenticated client on input. This client is created with `rhg_compute_tools.gcs._authenticate_client()` which reads from a path to credentials or use alternative authentication internal to `cloud.google.storage`.

I feel like this makes the process less magical and flexible enough for future development.