### PR TITLE
integrate remote scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ target/
 .pytest_cache
 # Rever
 rever/
+
+# jupyter
+*.ipynb_checkpoints

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,13 @@ History
 
 .. current developments
 
+v0.2.1
+------
+* Add remote scheduler deployment (part of dask_kubernetes 0.10)
+* Remove extraneous `GCSFUSE_TOKENS` env var no longer used in new worker images
+* Set library thread limits based on how many cpus are available for a single dask thread
+* Change formatting of the extra `env_items` passed to `get_cluster` to be a list rather than a list of dict-like name/value pairs
+
 v0.2.0
 ------
 

--- a/rhg_compute_tools/__init__.py
+++ b/rhg_compute_tools/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Michael Delgado"""
 __email__ = 'mdelgado@rhg.com'
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -233,8 +233,7 @@ def get_cluster(
     # start cluster and client and return
     # need more time to connect to remote scheduler
     if deploy_mode == "remote":
-        dask.config.set({"distributed.comm.timeouts.connect": "60s",
-                         "kubernetes.idle-timeout": idle_timeout})
+        dask.config.set({"kubernetes.idle-timeout": idle_timeout})
     cluster = KubeCluster.from_dict(
         template, deploy_mode=deploy_mode, idle_timeout=None
     )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ test_requirements = [
 
 setup(
     name='rhg_compute_tools',
-    version='0.2.0',
+    version='0.2.1',
     description="Tools for using compute.rhg.com and compute.impactlab.org",
     long_description=readme + '\n\n' + history,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
 - [x] tests added / passed (checking but really haven't added any b/c don't know how we could add tests that require connection to a remote pod on kubernetes)
 - [x] docs reflect changes
 - [x] passes ``flake8 rhg_compute_tools tests docs``
 - [x] entry in HISTORY.rst

* Add remote scheduler deployment (part of dask_kubernetes 0.10)
* Remove extraneous `GCSFUSE_TOKENS` env var no longer used in new worker images
* Set library thread limits based on how many cpus are available for a single dask thread
* Change formatting of the extra `env_items` passed to `get_cluster` to be a list rather than a list of dict-like name/value pairs