### PR TITLE
Allow labels and tolerations in get_cluster

### DIFF
--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -148,16 +148,19 @@ def get_cluster(
         template = yml.load(f, Loader=yml.SafeLoader)
     
     # update labels with default and user-provided labels
-    labels = template.get('metadata', {}).get('labels', {})
+    if ('metadata' not in template) or (template.get('metadata', {}) is None):
+        template['metadata'] = {}
+
+    if ('labels' not in template['metadata']) or (template['metadata']['labels'] is None):
+        template['metadata']['labels'] = {}
+
+    labels = template['metadata']['labels']
     
     if extra_worker_labels is not None:
         labels.update(extra_worker_labels)
 
     labels.update({
         'jupyter_user': os.environ.get('JUPYTERHUB_USER', socket.gethostname())})
-    
-    if not 'metadata' in template:
-        template['metadata'] = {}
         
     template['metadata']['labels'] = labels
     

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -175,8 +175,10 @@ def get_cluster(
     
     if (extra_pod_tolerations is not None) and (len(extra_pod_tolerations) > 0):
         if keep_default_tolerations:
+            print("Another shrubbery!!!")
             template['spec']['tolerations'].extend(extra_pod_tolerations)
         else:
+            print("Help help I'm being replaced!")
             template['spec']['tolerations'] = extra_pod_tolerations
 
     container = template['spec']['containers'][0]

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -112,11 +112,12 @@ def get_cluster(
     extra_pod_tolerations : list of dict, optional
         List of pod toleration dictionaries. For example, to match a node pool
         NoSchedule toleration, you might provide:
-        ```python
-        extra_pod_tolerations=[
-            {"effect": "NoSchedule", "key": "k8s.dask.org_dedicated", "operator": "Equal", "value": "worker-highcpu"},
-            {"effect": "NoSchedule", "key": "k8s.dask.org/dedicated", "operator": "Equal", "value": "worker-highcpu"}]
-        ```
+        
+        .. code-block:: python
+
+            extra_pod_tolerations=[
+                {"effect": "NoSchedule", "key": "k8s.dask.org_dedicated", "operator": "Equal", "value": "worker-highcpu"},
+                {"effect": "NoSchedule", "key": "k8s.dask.org/dedicated", "operator": "Equal", "value": "worker-highcpu"}]
 
     Returns
     -------

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -175,10 +175,8 @@ def get_cluster(
     
     if (extra_pod_tolerations is not None) and (len(extra_pod_tolerations) > 0):
         if keep_default_tolerations:
-            print("Another shrubbery!!!")
             template['spec']['tolerations'].extend(extra_pod_tolerations)
         else:
-            print("Help help I'm being replaced!")
             template['spec']['tolerations'] = extra_pod_tolerations
 
     container = template['spec']['containers'][0]


### PR DESCRIPTION
 - [x] closes #57 
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 rhg_compute_tools tests docs``
 - [ ] entry in HISTORY.rst

### Usage

To create cluster which will spin up workers with custom labels and tolerations:

```python
client, cluster = rhgk.get_cluster(
    extra_worker_labels={
        'project': 'my-project',
        'phase': 'phase2',
        'job': 'my-big-distributed-job',
    },
    extra_pod_tolerations=[
            {
                "effect": "NoSchedule",
                "key": "k8s.dask.org_dedicated",
                "operator": "Equal",
                "value": "worker-highcpu",
            },
            {
                "effect": "NoSchedule",
                "key": "k8s.dask.org/dedicated",
                "operator": "Equal",
                "value": "worker-highcpu",
            },
    ],
)
```