### PR TITLE
make gsutil API consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ rever/
 
 # jupyter
 *.ipynb_checkpoints
+
+# dask
+dask-worker-space/
+

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,15 @@ History
 
 .. current developments
 
+v0.2.3
+------
+* Make the gsutil API consistent, so that we have `cp`, `sync` and `rm`, each of which
+  accept the same args and kwargs (:issue:`69`)
+
+v0.2.2
+------
+* ?
+
 v0.2.1
 ------
 * Add remote scheduler deployment (part of dask_kubernetes 0.10)

--- a/docs/rhg_compute_tools.design.rst
+++ b/docs/rhg_compute_tools.design.rst
@@ -8,23 +8,23 @@ rhg\_compute\_tools.design.colors module
 ----------------------------------------
 
 .. automodule:: rhg_compute_tools.design.colors
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 rhg\_compute\_tools.design.plotting module
 ------------------------------------------
 
 .. automodule:: rhg_compute_tools.design.plotting
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 
 Module contents
 ---------------
 
 .. automodule:: rhg_compute_tools.design
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -129,6 +129,7 @@ def rm(path, flags=[]):
 
     cmd = "gsutil -m rm " + " ".join(["-" + f for f in flags]) + f" {path}"
 
+    print(f"Running cmd: {cmd}")
     cmd = shlex.split(cmd)
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
@@ -319,6 +320,8 @@ def sync(src, dest, flags=["r", "d"]):
         + " {} {}".format(src_gs, dest_gs)
     )
 
+    print(f"Running cmd: {cmd}")
+    
     cmd = shlex.split(cmd)
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -91,7 +91,7 @@ def _get_path_types(src, dest):
     return src_gs, dest_gs, dest_gcs
 
 
-def rm(path, cp_flags=[]):
+def rm(path, flags=[]):
     """Remove a file or recursively remove a directory from local
     path to GCS or vice versa. Must have already authenticated to use.
     Notebook servers are automatically authenticated, but workers
@@ -105,9 +105,9 @@ def rm(path, cp_flags=[]):
     path : str or :class:`pathlib.Path`
         The path to the source and destination file or directory.
         Either the `/gcs` or `gs:/` prefix will work.
-    cp_flags : list of str, optional
-        String of flags to add to the gsutil cp command. e.g.
-        `cp_flags=['r']` will run the command `gsutil -m rm -r...`
+    flags : list of str, optional
+        String of flags to add to the gsutil rm command. e.g.
+        `flags=['r']` will run the command `gsutil -m rm -r...`
         (recursive remove)
 
     Returns
@@ -124,7 +124,7 @@ def rm(path, cp_flags=[]):
 
     path = str(path).replace("/gcs/", "gs://")
 
-    cmd = "gsutil -m rm " + " ".join(["-" + f for f in cp_flags]) + f" {path}"
+    cmd = "gsutil -m rm " + " ".join(["-" + f for f in flags]) + f" {path}"
 
     cmd = shlex.split(cmd)
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -177,12 +177,17 @@ def replicate_directory_structure_on_gcs(src, dst, client):
         blob.upload_from_string("")
 
 
-def cp_to_gcs(*args, **kwargs):
-    """Deprecated. Use `cp_gcs`."""
-    return cp_gcs(*args, **kwargs)
-
+def cp_to_gcs(src, dest, cp_flags=[]):
+    """Deprecated. Use ``cp``."""
+    warnings.warn("Deprecated. Use `cp`")
+    return cp(src, dest, flags=cp_flags)
 
 def cp_gcs(src, dest, cp_flags=[]):
+    """Deprecated. Use ``cp``"""
+    warnings.warn("Deprecated. Use `cp`")
+    return cp(src, dest, flags=cp_flags)
+
+def cp(src, dest, flags=[]):
     """Copy a file or recursively copy a directory from local
     path to GCS or vice versa. Must have already authenticated to use.
     Notebook servers are automatically authenticated, but workers
@@ -196,9 +201,9 @@ def cp_gcs(src, dest, cp_flags=[]):
     src, dest : str
         The paths to the source and destination file or directory.
         If on GCS, either the `/gcs` or `gs:/` prefix will work.
-    cp_flags : list of str, optional
+    flags : list of str, optional
         String of flags to add to the gsutil cp command. e.g.
-        `cp_flags=['r']` will run the command `gsutil -m cp -r...`
+        `flags=['r']` will run the command `gsutil -m cp -r...`
         (recursive copy)
 
     Returns
@@ -227,7 +232,7 @@ def cp_gcs(src, dest, cp_flags=[]):
 
     cmd = (
         "gsutil -m cp "
-        + " ".join(["-" + f for f in cp_flags])
+        + " ".join(["-" + f for f in flags])
         + " {} {}".format(src_gs, dest_gs)
     )
 
@@ -247,12 +252,18 @@ def cp_gcs(src, dest, cp_flags=[]):
     return stdout, stderr, end_time - st_time
 
 
-def sync_to_gcs(*args, **kwargs):
-    """Deprecated. Use sync_gcs"""
-    return sync_gcs(*args, **kwargs)
+def sync_to_gcs(src, dest, sync_flags=[]):
+    """Deprecated. Use ``sync``"""
+    warnings.warn("Deprecated. Use `sync`.")
+    return sync(src, dest, flags=sync_flags)
+
+def sync_gcs(*args, **kwargs):
+    """Deprecated. Use ``sync``"""
+    warnings.warn("Deprecated. Use `sync`.")
+    return sync(src, dest, flags=sync_flags)
 
 
-def sync_gcs(src, dest, sync_flags=["r", "d"]):
+def sync(src, dest, flags=["r", "d"]):
     """Sync a directory from local to GCS or vice versa. Uses `gsutil rsync`.
     Must have already authenticated to use. Notebook servers
     are automatically authenticated, but workers need to pass the path
@@ -265,9 +276,9 @@ def sync_gcs(src, dest, sync_flags=["r", "d"]):
     src, dest : str
         The paths to the source and destination file or directory.
         If on GCS, either the `/gcs` or `gs:/` prefix will work.
-    sync_flags : list of str, optional
+    flags : list of str, optional
         String of flags to add to the gsutil cp command. e.g.
-        `sync_flags=['r','d']` will run the command `gsutil -m cp -r -d...`
+        `flags=['r','d']` will run the command `gsutil -m cp -r -d...`
         (recursive copy, delete any files on dest that are not on src).
         This is the default set of flags.
 
@@ -294,7 +305,7 @@ def sync_gcs(src, dest, sync_flags=["r", "d"]):
 
     cmd = (
         "gsutil -m rsync "
-        + " ".join(["-" + f for f in sync_flags])
+        + " ".join(["-" + f for f in flags])
         + " {} {}".format(src_gs, dest_gs)
     )
 


### PR DESCRIPTION
 - [x] closes #69
 - [ ] tests added / passed (no tests exist for gcs module yet)
 - [x] docs reflect changes
 - [ ] passes ``flake8 rhg_compute_tools tests docs`` (no introduced errors, but there are a lot of existing errors)
 - [x] entry in HISTORY.rst

Make the gsutil API consistent, so that we have `cp`, `sync` and `rm`, each of which accept the same args and kwargs. There are errors raised by travis for other modules.