### PR TITLE
isort everything + 1 change

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory is

--- a/rhg_compute_tools/cli.py
+++ b/rhg_compute_tools/cli.py
@@ -1,7 +1,8 @@
 import click
+
 from rhg_compute_tools.gcs import (
-    replicate_directory_structure_on_gcs,
     authenticated_client,
+    replicate_directory_structure_on_gcs,
 )
 
 

--- a/rhg_compute_tools/design/__init__.py
+++ b/rhg_compute_tools/design/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from rhg_compute_tools.design.colors import _load_colors
-from rhg_compute_tools.design.plotting import get_color_scheme, add_colorbar
+from rhg_compute_tools.design.plotting import add_colorbar, get_color_scheme
 
 _load_colors()
 

--- a/rhg_compute_tools/design/colors.py
+++ b/rhg_compute_tools/design/colors.py
@@ -1,7 +1,8 @@
 import os
-import numpy as np
+
 import matplotlib.cm
 import matplotlib.style
+import numpy as np
 from matplotlib.colors import LinearSegmentedColormap, ListedColormap
 
 RHG_COLOR_GRID = np.array(

--- a/rhg_compute_tools/design/plotting.py
+++ b/rhg_compute_tools/design/plotting.py
@@ -1,6 +1,6 @@
 import matplotlib.cm
-from matplotlib.colors import LinearSegmentedColormap
 import numpy as np
+from matplotlib.colors import LinearSegmentedColormap
 
 try:
     _string_types = (str, unicode)

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -3,12 +3,13 @@
 """Tools for interacting with GCS infrastructure."""
 
 import os
-from os.path import join, isdir, basename, exists
+import shlex
+import subprocess
+from datetime import datetime as dt
+from os.path import basename, exists, isdir, join
+
 from google.cloud import storage
 from google.oauth2 import service_account
-from datetime import datetime as dt
-import subprocess
-import shlex
 
 
 def authenticated_client(credentials=None, **client_kwargs):

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -1,16 +1,17 @@
 # -*- coding: utf-8 -*-
 """Tools for interacting with kubernetes."""
 
-from dask_kubernetes import KubeCluster
-import dask
-import dask.distributed as dd
-import yaml as yml
-import traceback as tb
 import os
 import socket
-import numpy as np
-from collections import Sequence
+import traceback as tb
 import warnings
+from collections import Sequence
+
+import dask
+import numpy as np
+import yaml as yml
+from dask import distributed as dd
+from dask_kubernetes import KubeCluster
 
 
 def traceback(ftr):

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -10,6 +10,7 @@ import os
 import socket
 import numpy as np
 from collections import Sequence
+import warnings
 
 
 def traceback(ftr):
@@ -108,7 +109,7 @@ def get_cluster(
     deploy_mode : str, optional
         Where to deploy the scheduler (on the same pod or a different pod)
     idle_timeout : str, optional
-        Number of seconds without active ommunication with the client before the 
+        Number of seconds without active ommunication with the client before the
         remote scheduler shuts down (ignored if ``deploy_mode=='local'``).
         Default is to not shut down for this reason.
     template_path : str, optional
@@ -121,12 +122,23 @@ def get_cluster(
     extra_pod_tolerations : list of dict, optional
         List of pod toleration dictionaries. For example, to match a node pool
         NoSchedule toleration, you might provide:
-        
+
         .. code-block:: python
 
             extra_pod_tolerations=[
-                {"effect": "NoSchedule", "key": "k8s.dask.org_dedicated", "operator": "Equal", "value": "worker-highcpu"},
-                {"effect": "NoSchedule", "key": "k8s.dask.org/dedicated", "operator": "Equal", "value": "worker-highcpu"}]
+                {
+                    "effect": "NoSchedule",
+                    "key": "k8s.dask.org_dedicated",
+                    "operator": "Equal",
+                    "value": "worker-highcpu"
+                },
+                {
+                    "effect": "NoSchedule",
+                    "key": "k8s.dask.org/dedicated",
+                    "operator": "Equal",
+                    "value": "worker-highcpu"
+                }
+            ]
 
     keep_default_tolerations : bool, optional
         Whether to append (default) or replace the default tolerations. Ignored if

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -110,7 +110,7 @@ def get_cluster(
     deploy_mode : str, optional
         Where to deploy the scheduler (on the same pod or a different pod)
     idle_timeout : str, optional
-        Number of seconds without active ommunication with the client before the
+        Number of seconds without active communication with the client before the
         remote scheduler shuts down (ignored if ``deploy_mode=='local'``).
         Default is to not shut down for this reason.
     template_path : str, optional

--- a/rhg_compute_tools/utils.py
+++ b/rhg_compute_tools/utils.py
@@ -1,14 +1,14 @@
+import collections.abc
+import dis
 import functools
+import inspect
 import itertools
 import json
-import numpy as np
 import os
-
-import dis
-import toolz
-import inspect
 import types
-import collections.abc
+
+import numpy as np
+import toolz
 
 
 def expand(func):

--- a/rhg_compute_tools/xarray.py
+++ b/rhg_compute_tools/xarray.py
@@ -1,6 +1,6 @@
-import xarray as xr
 import dask.array
-import dask.distributed as dd
+import xarray as xr
+from dask import distributed as dd
 
 
 def dataarrays_from_delayed(futures, client=None):
@@ -341,9 +341,10 @@ def dataset_from_delayed(futures, dim=None, client=None):
     return ds
 
 
+import functools
+
 import numpy as np
 import xarray as xr
-import functools
 
 
 def choose_along_axis(arr, axis=-1, replace=True, nchoices=1, p=None):

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@
 
 """The setup script."""
 
-from setuptools import setup, find_packages
 import re
+
+from setuptools import find_packages, setup
 
 with open("README.rst") as readme_file:
     readme = readme_file.read()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,5 +1,6 @@
-import pytest
 import click
+import pytest
+
 import rhg_compute_tools.cli
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,9 +3,10 @@ White-box testing to ensure that CLI passes variables correctly
 """
 
 
-import pytest
 import click
+import pytest
 from click.testing import CliRunner
+
 import rhg_compute_tools.cli
 from tests.fixtures import replicate_directory_structure_on_gcs_stub, tempfl_path
 

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -1,5 +1,6 @@
-import pytest
 import os
+
+import pytest
 
 import rhg_compute_tools
 
@@ -12,9 +13,10 @@ styles = [
 
 
 def test_imports():
-    import rhg_compute_tools.design
     import matplotlib.cm
     import matplotlib.colors
+
+    import rhg_compute_tools.design
 
     assert isinstance(
         matplotlib.cm.get_cmap("rhg_Blues"), matplotlib.colors.LinearSegmentedColormap

--- a/travis_pypi_setup.py
+++ b/travis_pypi_setup.py
@@ -4,15 +4,16 @@
 
 
 from __future__ import print_function
+
 import base64
 import json
 import os
 from getpass import getpass
+
 import yaml
-from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
-
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
 try:
     from urllib import urlopen


### PR DESCRIPTION
OK @delgadom i knowwww you don't like to mix formatter changes and other changes, but #65 actually fixed one of the two bugs I had noticed. The only other one was that warnings was not imported in kubernetes.py but was potentially being called. So this PR contains that one change, and other than that I just called `isort --profile black .` and added all those changes (isort v5 now has profiles so you can make sure that isort doesn't do anything that black would then revert). Importantly it doesn't mess up the importing AFTER sys.path in `conf.py`.

Fixes #75 