### PR TITLE
add tag argument to get_cluster

### DIFF
--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -227,7 +227,7 @@ def get_cluster(
                 r"$"
             ),
             r"\1",
-            image
+            name
         ) + tag
 
     if extra_pip_packages is not None:

--- a/rhg_compute_tools/kubernetes.py
+++ b/rhg_compute_tools/kubernetes.py
@@ -227,7 +227,7 @@ def get_cluster(
                 r"$"
             ),
             r"\1",
-            name
+            container["image"],
         ) + tag
 
     if extra_pip_packages is not None:


### PR DESCRIPTION
 - [x] closes #79 (or at least partly addresses it)
 - [ ] tests added / passed
 - [x] docs reflect changes
 - [ ] passes ``flake8 rhg_compute_tools tests docs``
 - [ ] entry in HISTORY.rst

Allows you to pass in a tag argument to `get_cluster`, which overrides just the tag of the default image in worker_template.yml. This is useful for pyTC images, where the base image is changed depending on the notebook you select, but the tag is dependent on the pyTC branch you're using.