### PR TITLE
switch bumpversion to setuptools_scm

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ v0.2.3
 ------
 * Make the gsutil API consistent, so that we have `cp`, `sync` and `rm`, each of which
   accept the same args and kwargs (:issue:`69`)
+* Swap ``bumpversion`` for ``setuptools_scm`` to handle versioning (:issue:`78`)
 
 v0.2.2
 ------

--- a/rhg_compute_tools/__init__.py
+++ b/rhg_compute_tools/__init__.py
@@ -2,6 +2,10 @@
 
 """Top-level package for RHG Compute Tools."""
 
+
+import pkg_resources
+
+
 __author__ = """Michael Delgado"""
 __email__ = "mdelgado@rhg.com"
-__version__ = "0.2.2"
+__version__ = pkg_resources.get_distribution("rhg_compute_tools").version

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.2.2
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:rhg_compute_tools/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ requirements = [
 
 setup_requirements = [
     "pytest-runner",
+    "setuptools_scm",
     # TODO(delgadom): put setup requirements (distutils extensions, etc.) here
 ]
 
@@ -31,7 +32,7 @@ test_requirements = [
 
 setup(
     name="rhg_compute_tools",
-    version="0.2.2",
+    use_scm_version=True,
     description="Tools for using compute.rhg.com and compute.impactlab.org",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
 - [x] closes #78
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 rhg_compute_tools tests docs``
 - [x] entry in HISTORY.rst

We used to handle versioning with `bumpversion`, this PR switches it to `setuptools_scm` because it's better maintained.