### PR TITLE
address strange memory blowup with rhg_compute_tools.xarray.dataarrays_from_delayed

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,7 @@ v0.2.3
 * Make the gsutil API consistent, so that we have `cp`, `sync` and `rm`, each of which
   accept the same args and kwargs (:issue:`69`)
 * Swap ``bumpversion`` for ``setuptools_scm`` to handle versioning (:issue:`78`)
-* Cast coordinates to dict before gathering in ``rhg_compute_tools.xarray.dataarrays_from_delayed`` and ``rhg_compute_tools.xarray.datasets_from_delayed``. This avoids a mysterious memory explosion on the local machine. Also add ``name`` in the metadata used by those functions so that the name of each dataarray or Variable is preserved.
+* Cast coordinates to dict before gathering in ``rhg_compute_tools.xarray.dataarrays_from_delayed`` and ``rhg_compute_tools.xarray.datasets_from_delayed``. This avoids a mysterious memory explosion on the local machine. Also add ``name`` in the metadata used by those functions so that the name of each dataarray or Variable is preserved. (:issue:`83`)
 
 v0.2.2
 ------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ v0.2.3
 * Make the gsutil API consistent, so that we have `cp`, `sync` and `rm`, each of which
   accept the same args and kwargs (:issue:`69`)
 * Swap ``bumpversion`` for ``setuptools_scm`` to handle versioning (:issue:`78`)
+* Cast coordinates to dict before gathering in ``rhg_compute_tools.xarray.dataarrays_from_delayed`` and ``rhg_compute_tools.xarray.datasets_from_delayed``. This avoids a mysterious memory explosion on the local machine. Also add ``name`` in the metadata used by those functions so that the name of each dataarray or Variable is preserved.
 
 v0.2.2
 ------


### PR DESCRIPTION
 - [x] closes #83
 - [x] tests added / passed (existing tests are sufficient)
 - [x] docs reflect changes (none needed)
 - [x] passes ``flake8 rhg_compute_tools tests docs`` (no new errors/warnings added)
 - [x] entry in HISTORY.rst

Gather `dict(ds.coords)` instead of `ds.coords` (see #83)