### PR TITLE
Minor fix to contradicting flake8 config rule

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [flake8]
-include = rhg_compute_tools tests docs
+include = rhg_compute_tools tests
 ignore =
 	E402,  # module level import not at top of file
 	E731,  # do not assign a lambda expression, use a def


### PR DESCRIPTION
Without this PR, our configs tell `flake8` to both include and ignore `docs`.

This PR prevents `flake8` from dealing with the contradiction by gathering and gaining sentience to wiping out all humanity.
