### PR TITLE
speed up metadata pulls

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ History
 
 .. current developments
 
+v1.1.1
+------
+* Refactor ``datasets_from_delayed`` to speed up
+
 v1.1
 ----
 * Add `gcs.ls` function


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 rhg_compute_tools tests docs``
 - [x] entry in HISTORY.rst

The file I modified passes the `flake8` test but I did not touch the rest of the files. No new tests needed as this does not change behavior, just speeds things up. Previously, we were calling `client.submit(task).result()` a whole bunch of times in succession. The change is to just call `client.gather()` once rather than all of the `Future.result()` calls.