### PR TITLE
drop matplotlib rebuild() call in deign.__init__

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,14 @@ History
 
 .. current developments
 
+current version
+---------------
+
+Compatibility
+~~~~~~~~~~~~~
+
+* Drop ``matplotlib.font_manager._rebuild()`` call in ``design.__init__`` - no longer supported (:issue:`96`)
+
 v1.1.1
 ------
 * Refactor ``datasets_from_delayed`` to speed up

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,17 +4,10 @@ History
 
 .. current developments
 
-current version
----------------
-
-Compatibility
-~~~~~~~~~~~~~
-
-* Drop ``matplotlib.font_manager._rebuild()`` call in ``design.__init__`` - no longer supported (:issue:`96`)
-
 v1.1.1
 ------
 * Refactor ``datasets_from_delayed`` to speed up
+* Drop ``matplotlib.font_manager._rebuild()`` call in ``design.__init__`` - no longer supported (:issue:`96`)
 
 v1.1
 ----

--- a/rhg_compute_tools/design/__init__.py
+++ b/rhg_compute_tools/design/__init__.py
@@ -5,6 +5,8 @@ from rhg_compute_tools.design.plotting import add_colorbar, get_color_scheme
 
 _load_colors()
 
+# the following lines are an attempt to add RHG fonts. they don't work. grumble grumble.
+
 # import matplotlib.font_manager as fm
 #
 # RHG_FONTS = [
@@ -25,9 +27,5 @@ _load_colors()
 #
 # for (sysfont, ext) in RHG_FONTS:
 #     fm.findfont(sysfont, fontext=ext, rebuild_if_missing=False)
-
-from matplotlib.font_manager import _rebuild
-
-_rebuild()
 
 __all__ = ["get_color_scheme", "add_colorbar"]


### PR DESCRIPTION
 - [x] closes #96 
 - [x] tests added / passed
 - [ ] docs reflect changes
 - [ ] passes ``flake8 rhg_compute_tools tests docs``
 - [x] entry in HISTORY.rst

Updates:
* Don't rebuild matplotlib cache on ``design.__init__``. That does seem like a questionable strategy anyway. Note we still need to figure out how to enable rhg styles/fonts :( 