### PR TITLE
add retry func

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ History
 
 .. current developments
 
+v1.1.3
+------
+* Add ``retry_with_timeout`` to ``rhg_compute_tools.utils.py``
+
 v1.1.2
 ------
 * Drop ``matplotlib.font_manager._rebuild()`` call in ``design.__init__`` - no longer supported (:issue:`96`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,6 @@ pytest-mock
 twine
 dask-gateway-server[local]
 ruamel.yaml
+rpy2
 
 # setuptools_scm

--- a/rhg_compute_tools/utils.py
+++ b/rhg_compute_tools/utils.py
@@ -531,7 +531,7 @@ def retry_with_timeout(func, retry_freq=10, n_tries=1, use_dask=True):
                     try:
                         return fut.result(timeout=retry_freq)
                     except dd.TimeoutError:
-                        del fut
+                        ...
         else:
             # non-dask version
             def this_func(q):

--- a/rhg_compute_tools/utils.py
+++ b/rhg_compute_tools/utils.py
@@ -505,9 +505,7 @@ def retry_with_timeout(func, retry_freq=10, n_tries=1, use_dask=True):
         >>> @retry_with_timeout(retry_freq=.5, n_tries=1)
         ... def wait_func(timeout):
         ...     time.sleep(timeout)
-        ...     print("success")
         >>> wait_func(.1)
-        success
         >>> wait_func(1)
         Traceback (most recent call last):
             ...

--- a/tests/test_rhg_compute_tools.py
+++ b/tests/test_rhg_compute_tools.py
@@ -83,15 +83,15 @@ def test_retry_with_timeout():
     def test_suite(use_dask=True):
         with pytest.raises(TimeoutError):
             utils.retry_with_timeout(
-                wait_func, 5, retry_freq=0.1, n_retries=1, use_dask=use_dask
-            )
+                wait_func, retry_freq=0.1, n_retries=1, use_dask=use_dask
+            )(5)
         with pytest.raises(TimeoutError):
             utils.retry_with_timeout(
-                wait_func, 1, retry_freq=0.4, n_retries=2, use_dask=use_dask
-            )
+                wait_func, retry_freq=0.4, n_retries=2, use_dask=use_dask
+            )(1)
         return utils.retry_with_timeout(
-            wait_func, 0.1, retry_freq=1, n_retries=1, use_dask=use_dask
-        )
+            wait_func, retry_freq=1, n_retries=1, use_dask=use_dask
+        )(0.1)
 
     # first test with non-dask timeout approach
     test_suite()

--- a/tests/test_rhg_compute_tools.py
+++ b/tests/test_rhg_compute_tools.py
@@ -83,14 +83,14 @@ def test_retry_with_timeout():
     def test_suite(use_dask=True):
         with pytest.raises(TimeoutError):
             utils.retry_with_timeout(
-                wait_func, retry_freq=0.1, n_retries=1, use_dask=use_dask
+                wait_func, retry_freq=0.1, n_tries=1, use_dask=use_dask
             )(5)
         with pytest.raises(TimeoutError):
             utils.retry_with_timeout(
-                wait_func, retry_freq=0.4, n_retries=2, use_dask=use_dask
+                wait_func, retry_freq=0.4, n_tries=2, use_dask=use_dask
             )(1)
         return utils.retry_with_timeout(
-            wait_func, retry_freq=1, n_retries=1, use_dask=use_dask
+            wait_func, retry_freq=1, n_tries=1, use_dask=use_dask
         )(0.1)
 
     # first test with non-dask timeout approach


### PR DESCRIPTION
 - [x] tests added / passed
 - [x] docs reflect changes
 - [x] passes ``flake8 rhg_compute_tools tests docs`` (for the files I changed)
 - [x] entry in HISTORY.rst

Added a decorator to execute a function with timeout features, either locally or from a dask worker.