### PR TITLE
add dask kwargs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ History
 
 .. current developments
 
+v1.1.4
+------
+* Add ``dask_kwargs`` to the ``rhg_compute_tools.xarray`` functions
+
 v1.1.3
 ------
 * Add ``retry_with_timeout`` to ``rhg_compute_tools.utils.py``

--- a/tests/set_gateway_config.py
+++ b/tests/set_gateway_config.py
@@ -6,7 +6,7 @@ r = requests.get(
     "https://raw.githubusercontent.com/RhodiumGroup/helm-chart/master/values.yml"
 )
 
-yaml = YAML(type="safe", pure=True)
+yaml = YAML(typ="safe", pure=True)
 data = yaml.load(r.content)["dask-gateway"]["gateway"]["extraConfig"]["optionHandler"]
 
 # change float cores to int cores b/c float not allowed for local cluster

--- a/tests/set_gateway_config.py
+++ b/tests/set_gateway_config.py
@@ -1,14 +1,13 @@
 import requests
-from ruamel import yaml
+from ruamel.yaml import YAML
 
 # TODO: change this branch to master when gateway stuff is merged
 r = requests.get(
     "https://raw.githubusercontent.com/RhodiumGroup/helm-chart/master/values.yml"
 )
 
-data = yaml.safe_load(r.content)["dask-gateway"]["gateway"]["extraConfig"][
-    "optionHandler"
-]
+yaml = YAML(type="safe", pure=True)
+data = yaml.load(r.content)["dask-gateway"]["gateway"]["extraConfig"]["optionHandler"]
 
 # change float cores to int cores b/c float not allowed for local cluster
 

--- a/tests/test_rhg_compute_tools.py
+++ b/tests/test_rhg_compute_tools.py
@@ -105,7 +105,7 @@ def test_retry_with_timeout():
                 test_func, retry_freq=0.4, n_tries=2, use_dask=use_dask
             )(1)
         return utils.retry_with_timeout(
-            test_func, retry_freq=5, n_tries=1, use_dask=use_dask
+            test_func, retry_freq=10, n_tries=1, use_dask=use_dask
         )(0.1)
 
     # test with dask timeout approach on workers


### PR DESCRIPTION
- [x] tests added / passed
 - [x] docs reflect changes
 - [ ] passes ``flake8 rhg_compute_tools tests docs``
 - [x] entry in HISTORY.rst

Add the ability to pass kwargs to `client.submit` and `client.gather` as part of the `rhg_compute_tools.xarray` functions. I came across a situation where I wanted to pass the `priority` kwarg, so figured we might as well add the ability to pass any arbitrary kwarg here.