### PR TITLE
raise for nonzero gsutil status code in cp

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,7 @@ History
 v1.2.1
 ------
 Bug fixes:
-* raise error on gsutil nonzero status in ``rhg_compute_tools.gcs.cp`` (:pull:`105`)
+* raise error on gsutil nonzero status in ``rhg_compute_tools.gcs.cp`` (``PR #105``)
 
 v1.2
 ----

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,17 @@ History
 
 .. current developments
 
+v1.2.1
+------
+Bug fixes:
+* raise error on gsutil nonzero status in ``rhg_compute_tools.gcs.cp`` (:pull:`105`)
+
+v1.2
+----
+New features:
+* Adds google storage directory marker utilities and rctools gcs mkdirs command line app
+
+
 v1.1.4
 ------
 * Add ``dask_kwargs`` to the ``rhg_compute_tools.xarray`` functions

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -243,6 +243,9 @@ def cp(src, dest, flags=[]):
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
 
+    if p.returncode != 0:
+        raise ValueError(stderr)
+
     # need to add directories if you were recursively copying a directory
     if isdir(src_gcs) and dest_gcs.startswith("/gcs/"):
         # now make directory blobs on gcs so that gcsfuse recognizes it


### PR DESCRIPTION
rhg_compute_tools.gcs.cp should raise an error when the subprocess call to gsutil fails. this checks the status code and raises if nonzero.