### PR TITLE
Fix extra need for storage.bucket.get GCS permissions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ Current version (unreleased)
 * Add `utils.get_repo_state` and `xarray.document_dataset` functions
 * Drop explicit testing of dask.gateway rpy2 functionality
 * Bugfix in sphinx docs
+* Fix to avoid internal calls to GCS API requiring unessesary storage.bucket.get permissions. Will now throw AssertionError if bucket is not found.
 
 v1.2.1
 ------

--- a/rhg_compute_tools/gcs.py
+++ b/rhg_compute_tools/gcs.py
@@ -70,7 +70,9 @@ def get_bucket(
     bucket : :py:class:`google.cloud.storage.bucket.Bucket`
     """
     client = authenticated_client(credentials=credentials, **client_kwargs)
-    result = client.get_bucket(bucket_name)
+    result = client.bucket(bucket_name)
+    assert bucket.exists()
+
 
     if return_client:
         result = (result, client)
@@ -170,7 +172,8 @@ def replicate_directory_structure_on_gcs(src, dst, client):
     bucket_name = dst.split("/")[0]
     blob_path = "/".join(dst.split("/")[1:])
 
-    bucket = client.get_bucket(bucket_name)
+    bucket = client.bucket(bucket_name)
+    assert bucket.exists()
 
     for d, dirnames, files in os.walk(src):
         dest_path = os.path.join(blob_path, os.path.relpath(d, src))
@@ -388,7 +391,7 @@ def create_directory_markers(bucket_name, project=None, client=None, prefix=None
     if client is None:
         client = storage.Client(project=project)
 
-    bucket = client.get_bucket(bucket_name)
+    bucket = client.bucket(bucket_name)
     assert bucket.exists()
 
     # Create empty blob for any non-exist directories


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [x] docs reflect changes
 - [ ] passes ``flake8 rhg_compute_tools tests docs``
 - [x] entry in HISTORY.rst

This fixes issues with users requiring additional GCS permissions to operate on objects within GCS buckets.

The trouble is that google.storage.client's get_bucket() method requires `storage.bucket.get` permissions to get a successful response from the  GCS API. To work around this I switch to use the `client.bucket()` method to instantiate Buckets without needing these extra permissions on GCS. 

One hitch with this is that get_bucket() checks the bucket exists and grabs additional metadata from GCS. I made up for this by asserting bucket.exists() where the change was made. It looks like this is how it was handled in other parts of this module. Maybe we should be throwing a `google.cloud.exceptions.NotFound` exception instead because this is what client.get_bucket throws. I'm not sure what the expected behavior should be. This might be a non-issue or a problem for another time.
